### PR TITLE
DEVOPS-2054: Missing deprecated filters for upgrade

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -34,7 +34,7 @@
     make {{python_build_opts_default}} {{python_build_opts}}
   args:
     chdir: "{{python_src_pkg_dir}}"
-  when: (python_installed | failed) or (python_force_build)
+  when: (python_installed is failed) or (python_force_build)
 
 - name: Install Custom Python
   command: >
@@ -42,6 +42,6 @@
   args:
     chdir: "{{python_src_pkg_dir}}"
   become: true
-  when: (python_installed | failed) or (python_force_build)
+  when: (python_installed is failed) or (python_force_build)
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/setuptools.yml
+++ b/tasks/setuptools.yml
@@ -31,7 +31,7 @@
     {{python_bin}} {{python_setuptools_pkg}} --to-dir {{python_setuptools_pkg_dir}}
   args:
     chdir: "{{python_setuptools_src_dir}}"
-  when: (setuptools_installed | failed) or (setuptools_force_build)
+  when: (setuptools_installed is failed) or (setuptools_force_build)
 
 - name: Install pip
   command: "{{python_bin}} -m ensurepip"


### PR DESCRIPTION
Fixing deprecation notices for Ansible 2.9 reported on several builds